### PR TITLE
Added support for subdomains in one zone file.

### DIFF
--- a/certbot-hetzner-auth.sh
+++ b/certbot-hetzner-auth.sh
@@ -2,15 +2,25 @@
 
 token=$(cat /etc/hetzner-dns-token)
 
+subdomainCount=$(echo $CERTBOT_DOMAIN | grep -o "\." | wc -l)
+subdomainCount=$((subdomainCount+1))
+
+while [[ -z $zone_id && $subdomainCount -ge 2 ]];do
+
+search_name=$( echo $CERTBOT_DOMAIN | rev | cut -d'.' -f 1-$subdomainCount | rev)
+subdomainCount=$((subdomainCount-1))
+
 zone_id=$(curl \
-	-H "Auth-API-Token: ${token}" \
-	"https://dns.hetzner.com/api/v1/zones?search_name=${CERTBOT_DOMAIN}" | \
-	jq ".\"zones\"[] | select(.name == \"${CERTBOT_DOMAIN}\") | .id" 2>/dev/null | tr -d '"')
+        -H "Auth-API-Token: ${token}" \
+        "https://dns.hetzner.com/api/v1/zones?search_name=${search_name}" | \
+        jq ".\"zones\"[] | select(.name == \"${search_name}\") | .id" 2>/dev/null | tr -d '"')
+
+done
 
 curl -X "POST" "https://dns.hetzner.com/api/v1/records" \
      -H 'Content-Type: application/json' \
      -H "Auth-API-Token: ${token}" \
-     -d "{ \"value\": \"${CERTBOT_VALIDATION}\", \"ttl\": 86400, \"type\": \"TXT\", \"name\": \"_acme-challenge\", \"zone_id\": \"${zone_id}\" }" > /dev/null 2>/dev/null
+     -d "{ \"value\": \"${CERTBOT_VALIDATION}\", \"ttl\": 300, \"type\": \"TXT\", \"name\": \"_acme-challenge.${CERTBOT_DOMAIN}.\", \"zone_id\": \"${zone_id}\" }" > /dev/null 2>/dev/null
 
 # just make sure we sleep for a while (this should be a dig poll loop)
 sleep 30

--- a/certbot-hetzner-cleanup.sh
+++ b/certbot-hetzner-cleanup.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
-set -x
-
 token=$(cat /etc/hetzner-dns-token)
 
+subdomainCount=$(echo $CERTBOT_DOMAIN | grep -o "\." | wc -l)
+subdomainCount=$((subdomainCount+1))
+
+while [[ -z $zone_id && $subdomainCount -ge 2 ]];do
+
+search_name=$( echo $CERTBOT_DOMAIN | rev | cut -d'.' -f 1-$subdomainCount | rev)
+subdomainCount=$((subdomainCount-1))
+
 zone_id=$(curl \
-	-H "Auth-API-Token: ${token}" \
-	"https://dns.hetzner.com/api/v1/zones?search_name=${CERTBOT_DOMAIN}" | \
-	jq ".\"zones\"[] | select(.name == \"${CERTBOT_DOMAIN}\") | .id" 2>/dev/null | tr -d '"')
+        -H "Auth-API-Token: ${token}" \
+        "https://dns.hetzner.com/api/v1/zones?search_name=${search_name}" | \
+        jq ".\"zones\"[] | select(.name == \"${search_name}\") | .id" 2>/dev/null | tr -d '"')
+
+done
 
 record_ids=$(curl \
-	-H "Auth-API-Token: $token" \
-	"https://dns.hetzner.com/api/v1/records?zone_id=$zone_id" | \
-	jq ".\"records\"[] | select(.name == \"_acme-challenge\") | .id" 2>/dev/null | tr -d '"')
+        -H "Auth-API-Token: $token" \
+        "https://dns.hetzner.com/api/v1/records?zone_id=$zone_id" | \
+       jq ".\"records\"[] | select(.name == \"_acme-challenge.${CERTBOT_DOMAIN}.\") | .id" 2>/dev/null | tr -d '"')
 
 for record_id in $record_ids
 do


### PR DESCRIPTION
Hi Dominik,

I implemented the subdomain support in one zone file without break your use case I thought (the approach you meantioned in my last pull request) . The design is tested offline and with several wildcard certificates online.

I'm not shure if it is possible to have in the hetzner dns console zones for subdomains. I tried to create a subdomain with the following response from the dns console api:

`..."error":{"message":"422 : invalid TLD","code":422}...`

I checked the hetzner documentation at https://docs.hetzner.com/dns-console/dns/general/zone-file-example

and find the following **Note** in the Chpater **"Delegation of a subdomain to a new zone"**

> Delegation of a subdomain to a new zone
> As an alternative to the procedure described under Sub domain, a delegation of subdomains to another DNS server is possible.

> Note: In the DNS Console, it is not possible to create DNS zones for subdomains! Here subdomains can only be defined as described in the section Sub domain.



