### PR TITLE
Update auf api.hetzner.cloud

### DIFF
--- a/certbot-hetzner-cleanup.sh
+++ b/certbot-hetzner-cleanup.sh
@@ -1,20 +1,15 @@
 #!/bin/bash
 
-token=$(cat /etc/hetzner-dns-token)
+token=${HETZNER_API_TOKEN:-$(cat /etc/hetzner-dns-token)}
 search_name=$( echo $CERTBOT_DOMAIN | rev | cut -d'.' -f 1,2 | rev)
+sub_name=$( echo $CERTBOT_DOMAIN | rev | cut -d'.' -f 3- | rev)
 
-zone_id=$(curl \
-        -H "Auth-API-Token: ${token}" \
-        "https://dns.hetzner.com/api/v1/zones?search_name=${search_name}" | \
-        jq ".\"zones\"[] | select(.name == \"${search_name}\") | .id" 2>/dev/null | tr -d '"')
+if ! test -z ${sub_name}
+then
+	sub_name=.${sub_name}
+fi
 
-record_ids=$(curl \
-        -H "Auth-API-Token: $token" \
-        "https://dns.hetzner.com/api/v1/records?zone_id=$zone_id" | \
-       jq ".\"records\"[] | select(.name == \"_acme-challenge.${CERTBOT_DOMAIN}.\") | .id" 2>/dev/null | tr -d '"')
-
-for record_id in $record_ids
-do
-        curl -H "Auth-API-Token: $token" \
-                -X "DELETE" "https://dns.hetzner.com/api/v1/records/${record_id}" > /dev/null 2> /dev/null
-done
+curl	-so/dev/null \
+	-H "Authorization: Bearer ${token}" \
+	-H 'Content-Type: application/json' \
+	-X DELETE https://api.hetzner.cloud/v1/zones/${search_name}/rrsets/_acme-challenge${sub_name}/TXT


### PR DESCRIPTION
Hetzner schaltet im Mai 2026 dns.hetzner.com ab, man soll nun api.hetzner.cloud verwenden.

Natürlich gibt es einige Änderungen der API. Speziell braucht es die zone_id nicht mehr, man kann die Zone auch beim Namen nennen. Das macht es etwas einfacher (nur noch ein curl Aufruf). Aber man darf nun auch kein Punkt mehr am Ende des Domainnamens haben.

Das ganze ist inkompatibel mit der alten API.

Ich hoffe meine Änderung ist für andere genau so nützlich wie das Original für mich die letzten Jahre nützlich war. :-)